### PR TITLE
Add diam

### DIFF
--- a/docs/src/lib/methods.md
+++ b/docs/src/lib/methods.md
@@ -17,6 +17,7 @@ CurrentModule = IntervalMatrices
 inf
 sup
 mid
+diam
 rand
 sample
 split

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -275,13 +275,5 @@ A matrix `B` of the same shape as `A` such that `B[i, j] == diam(A[i, j])` for
 each `i` and `j`.
 """
 function diam(A::IntervalMatrix{T}) where {T}
-    m, n = size(A)
-    B = Matrix{T}(undef, m, n)
-    @inbounds for j in 1:n
-        for i in 1:m
-            itv = A[i, j]
-            B[i, j] = (sup(itv) - inf(itv))
-        end
-    end
-    return B
+    return map(diam, A)
 end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,7 +1,7 @@
 import Base: split,
              ∈
 import Random: rand
-import IntervalArithmetic: inf, sup, mid
+import IntervalArithmetic: inf, sup, mid, diam
 
 """
     AbstractIntervalMatrix{IT} <: AbstractMatrix{IT}
@@ -255,6 +255,32 @@ function sample(A::IntervalMatrix{T}; rng::AbstractRNG=GLOBAL_RNG) where {T}
         for i in 1:m
             itv = A[i, j]
             B[i, j] = (sup(itv) - inf(itv)) * rand(rng) + inf(itv)
+        end
+    end
+    return B
+end
+
+"""
+    diam(A::IntervalMatrix{T}) where {T}
+
+Return a matrix whose entries describe the diameters of the intervals.
+
+### Input
+
+- `A` -- interval matrix
+
+### Output
+
+A matrix `B` of the same shape as `A` such that `B[i, j] == diam(A[i, j])` for
+each `i` and `j`.
+"""
+function diam(A::IntervalMatrix{T}) where {T}
+    m, n = size(A)
+    B = Matrix{T}(undef, m, n)
+    @inbounds for j in 1:n
+        for i in 1:m
+            itv = A[i, j]
+            B[i, j] = (sup(itv) - inf(itv))
         end
     end
     return B

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ end
     m2 = copy(m)
     @test m2 isa IntervalMatrix && m.mat == m2.mat
     @test l == inf.(m) && r == sup.(m) && c == mid.(m)
-    @test d == r - l
+    @test d ≈ r - l
 end
 
 @testset "Interval matrix exponential" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,9 +39,11 @@ end
     l = inf(m)
     r = sup(m)
     c = mid(m)
+    d = diam(m)
     m2 = copy(m)
     @test m2 isa IntervalMatrix && m.mat == m2.mat
     @test l == inf.(m) && r == sup.(m) && c == mid.(m)
+    @test d == r - l
 end
 
 @testset "Interval matrix exponential" begin


### PR DESCRIPTION
The straightforward implementation `diam2(A) = sup(A) - inf(A)` is much slower:

```julia
julia> A = rand(IntervalMatrix)
2×2 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
 [-1.35363, -0.49611]   [-0.837484, 1.52784]
 [-0.153475, 0.147587]  [-0.109807, 1.50446]

julia> @btime diam($A)
  43.767 ns (1 allocation: 112 bytes)
2×2 Array{Float64,2}:
 0.857517  2.36532
 0.301062  1.61426

julia> @btime diam2($A)
  150.805 ns (5 allocations: 368 bytes)
2×2 Array{Float64,2}:
 0.857517  2.36532
 0.301062  1.61426
```