### PR TITLE
Faster square function

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -48,24 +48,24 @@ matrix is NP-hard. SAC 2005.
 function square(A::IntervalMatrix)
     B = similar(A.mat)
     n = checksquare(A)
-    for j in 1:n
+
+    # case i == j
+    @inbounds for j in 1:n
+        B[j, j] = pow(A[j, j], 2)
+        for k in 1:n
+            k == j && continue
+            B[j, j] += A[j, k] * A[k, j]
+        end
+    end
+
+    # case i ≠ j
+    @inbounds for j in 1:n
         for i in 1:n
-            if i == j
-                res = A[i, i]^2
-                for k in 1:n
-                    if k != i
-                        res += A[i, k] * A[k, i]
-                    end
-                end
-                B[i, i] = res
-            else
-                res = A[i, j] * (A[i, i] + A[j, j])
-                for k in 1:n
-                    if k != i && k != j
-                        res += A[i, k] * A[k, j]
-                    end
-                end
-                B[i, j] = res
+            i == j && continue
+            B[i, j] = A[i, j] * (A[j, j] + A[i, i])
+            for k in 1:n
+                (k == i || k == j) && continue
+                B[i, j] += A[i, k] * A[k, j]
             end
         end
     end


### PR DESCRIPTION
The biggest speed difference comes from using `IntervalArithmetic.pow`. In the random examples that i tried, i didn't find differences in the size of the intervals.

```
n = 2
2
M = rand(IntervalMatrix, n, n)
3
@btime square($M)
  3.366 μs (88 allocations: 3.89 KiB)
2×2 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
  [0.0409632, 4.74014]  [-1.66928, 5.37961]  
 [-1.49507, 4.81819]     [0.0409632, 5.80631]
1
@btime square_v2($M)
  162.732 ns (2 allocations: 160 bytes)
2×2 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
  [0.0409632, 4.74014]  [-1.66928, 5.37961]  
 [-1.49507, 4.81819]     [0.0409632, 5.80631]
```