### PR TITLE
#49 - Convenience constructor for identity matrix

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -41,6 +41,11 @@ getindex(M::IntervalMatrix, i::Int) = getindex(M.mat, i)
 setindex!(M::IntervalMatrix, X, inds...) = setindex!(M.mat, X, inds...)
 copy(M::IntervalMatrix) = IntervalMatrix(copy(M.mat))
 
+# constructor from uniform scaling
+function IntervalMatrix(αI::UniformScaling{Interval{T}}, n, m=n) where {T}
+    return IntervalMatrix(Matrix(αI, n, m))
+end
+
 """
     opnorm(A::IntervalMatrix, p::Real=Inf)
 

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -28,6 +28,34 @@ julia> A = IntervalMatrix([-0.9±0.1 0±0; 0±0 -0.9±0.1])
  [-1, -0.799999]   [0, 0]
   [0, 0]          [-1, -0.799999]
 ```
+
+An interval matrix proportional to the identity matrix can be built using the
+`UniformScaling` operator from the standard library `LinearAlgebra`. For example,
+
+```jldoctest interval_uniform_scaling
+julia> using LinearAlgebra
+
+julia> IntervalMatrix(Interval(1)*I, 2)
+2×2 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
+ [1, 1]  [0, 0]
+ [0, 0]  [1, 1]
+```
+The number of columns can be specified as a third argument, creating a rectangular
+``m × n`` matrix such that only the entries in the main diagonal,
+``(1, 1), (2, 2), …,  (k, k)`` are specified, where ``k = \\min(m, n)``:
+
+```jldoctest interval_uniform_scaling
+julia> IntervalMatrix(Interval(-1, 1)*I, 2, 3)
+2×3 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
+ [-1, 1]   [0, 0]  [0, 0]
+  [0, 0]  [-1, 1]  [0, 0]
+
+julia> IntervalMatrix(Interval(-1, 1)*I, 3, 2)
+3×2 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
+ [-1, 1]   [0, 0]
+ [0, 0]  [-1, 1]
+ [0, 0]   [0, 0]
+```
 """
 struct IntervalMatrix{T, IT<:Interval{T}, MT<:AbstractMatrix{IT}} <: AbstractIntervalMatrix{IT}
     mat::MT

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -42,7 +42,7 @@ setindex!(M::IntervalMatrix, X, inds...) = setindex!(M.mat, X, inds...)
 copy(M::IntervalMatrix) = IntervalMatrix(copy(M.mat))
 
 # constructor from uniform scaling
-function IntervalMatrix(αI::UniformScaling{Interval{T}}, m, n=m) where {T}
+function IntervalMatrix(αI::UniformScaling{Interval{T}}, m::Integer, n::Integer=m) where {T}
     return IntervalMatrix(Matrix(αI, m, n))
 end
 

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -53,8 +53,8 @@ julia> IntervalMatrix(Interval(-1, 1)*I, 2, 3)
 julia> IntervalMatrix(Interval(-1, 1)*I, 3, 2)
 3×2 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
  [-1, 1]   [0, 0]
- [0, 0]  [-1, 1]
- [0, 0]   [0, 0]
+  [0, 0]  [-1, 1]
+  [0, 0]   [0, 0]
 ```
 """
 struct IntervalMatrix{T, IT<:Interval{T}, MT<:AbstractMatrix{IT}} <: AbstractIntervalMatrix{IT}

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -42,8 +42,8 @@ setindex!(M::IntervalMatrix, X, inds...) = setindex!(M.mat, X, inds...)
 copy(M::IntervalMatrix) = IntervalMatrix(copy(M.mat))
 
 # constructor from uniform scaling
-function IntervalMatrix(αI::UniformScaling{Interval{T}}, n, m=n) where {T}
-    return IntervalMatrix(Matrix(αI, n, m))
+function IntervalMatrix(αI::UniformScaling{Interval{T}}, m, n=m) where {T}
+    return IntervalMatrix(Matrix(αI, m, n))
 end
 
 """


### PR DESCRIPTION
Closes #49.

Remains:

- [x] Add test
- [x] Show this use case, eg. in the docs or in the main docstring of the type (or both places).