### PR TITLE
#110 - Fix docs building on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ## Documentation: http://docs.travis-ci.com/user/languages/julia/
-
 codecov: true
 
 language: julia
@@ -21,11 +20,9 @@ git:
   depth: 99999999
 
 matrix:
+  fast_finish: true
   allow_failures:
     - julia: nightly
-  fast_finish: true
-
-jobs:
   include:
     - stage: "Documentation"
       julia: 1.3


### PR DESCRIPTION
Closes #110.

I could not make both documentation and `allowed_failures` work together unless doing something like [this](https://github.com/JuliaReach/Reachability.jl/blob/bddd0e372fd4a533bbe5b0dcedc04603cdcd18fc/.travis.yml).