### PR TITLE
#4 - Implement scaling-and-squaring method

### DIFF
--- a/docs/src/lib/methods.md
+++ b/docs/src/lib/methods.md
@@ -32,6 +32,7 @@ scale!
 
 ```@docs
 exp_overapproximation
+scale_and_square
 exp_underapproximation
 ```
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,4 +1,4 @@
-import Base: +, -, *
+import Base: +, -, *, /
 
 # =========================
 # Addition operations
@@ -29,6 +29,8 @@ import Base: +, -, *
 
 *(x::Number, M::IntervalMatrix) = Interval(x) * M
 *(M::IntervalMatrix, x::Number) = Interval(x) * M
+
+/(M::IntervalMatrix, x::Number) = IntervalMatrix(M ./ x)
 
 *(M1::IntervalMatrix, M2::AbstractMatrix) = IntervalMatrix(M1.mat * M2)
 *(M1::AbstractMatrix, M2::IntervalMatrix) = IntervalMatrix(M1 * M2.mat)

--- a/src/exponential.jl
+++ b/src/exponential.jl
@@ -200,6 +200,40 @@ function _exp_remainder_series(A::IntervalMatrix{T}, t, p; n=checksquare(A)) whe
 end
 
 """
+    scale_and_square(A::IntervalMatrix{T}, l::Integer, t, p)
+
+Compute the matrix exponential using scaling and squaring.
+
+### Input
+
+- `A` -- interval matrix
+- `l` -- scaling-and-squaring order
+- `t` -- non-negative time value
+- `p` -- order of the approximation
+
+### Algorithm
+
+We use the algorithm in [1, Section 4.3], which first scales `A` by factor
+``2^{-l}``, computes the matrix exponential for the scaled matrix, and then
+squares the result ``l`` times.
+
+```math
+    \\exp(A * 2^{-l})^{2^l}
+```
+
+[1] Goldsztejn, Alexandre, Arnold Neumaier. "On the exponentiation of interval
+matrices". Reliable Computing. 2014.
+"""
+function scale_and_square(A::IntervalMatrix{T}, l::Integer, t, p) where {T}
+    A_scaled = A / (interval(T(2))^l)
+    E = exp_overapproximation(A_scaled, t, p)
+    for i in 1:l
+        E = square(E)
+    end
+    return E
+end
+
+"""
     exp_underapproximation(M::IntervalMatrix{T, Interval{T}}, t, p) where {T}
 
 Overapproximation of the exponential of an interval matrix.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,18 +30,18 @@ end
           IntervalMatrix([0.0..2.6 0.0..7.0; -2.0..0.0 -0.2..0.2])
     # multiply scalar and interval matrix
     x = 1.0
-    for A2 in [x * A, A * x]
+    for A2 in [x * A, A * x, A / x]
         @test A2 == A && typeof(A2) == typeof(A)
     end
 
-   # arithmetic closure using interval matrices and non-interval matrices
-   Ainf = inf(A)
-   @test A + Ainf isa IntervalMatrix
-   @test Ainf + A isa IntervalMatrix
-   @test A - Ainf isa IntervalMatrix
-   @test Ainf - A isa IntervalMatrix
-   @test A * Ainf isa IntervalMatrix
-   @test Ainf * A isa IntervalMatrix
+    # arithmetic closure using interval matrices and non-interval matrices
+    Ainf = inf(A)
+    @test A + Ainf isa IntervalMatrix
+    @test Ainf + A isa IntervalMatrix
+    @test A - Ainf isa IntervalMatrix
+    @test Ainf - A isa IntervalMatrix
+    @test A * Ainf isa IntervalMatrix
+    @test Ainf * A isa IntervalMatrix
 end
 
 @testset "Interval matrix methods" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using IntervalMatrices, Test, LinearAlgebra
 
+using IntervalMatrices: scale_and_square
+
 @testset "Interval arithmetic" begin
     a = -1.5 ± 0.5
     b = -1..1
@@ -65,9 +67,14 @@ end
 
 @testset "Interval matrix exponential" begin
     m = IntervalMatrix([-1.1..0.9 -4.1.. -3.9; 3.9..4.1 -1.1..0.9])
-    a_over = exp_overapproximation(m, 1.0, 4)
-    a_under = exp_underapproximation(m, 1.0, 4)
-    @test a_over isa IntervalMatrix && a_under isa IntervalMatrix
+    overapp1 = exp_overapproximation(m, 1.0, 4)
+    overapp2 = scale_and_square(m, 5, 1.0, 4)
+    underapp = exp_underapproximation(m, 1.0, 4)
+
+    @test underapp isa IntervalMatrix
+    for overapp in [overapp1, overapp2]
+        @test overapp isa IntervalMatrix
+    end
 end
 
 @testset "Interval matrix split" begin


### PR DESCRIPTION
Closes #4.

This PR does not expose the algorithm to the API. That requires an extension of the interface with more algorithms and arguments.
Note that the scaling-and-squaring algorithm itself could become parametric in the algorithm for computing the (scaled) matrix exponential. It should be checked that this inner algorithm is not scaling-and-squaring again.

As a side note, I first wanted to write `@test underapp ⊆ overapp`, but that failed. So I guess at least one implementation is incorrect.
```julia
julia> overapp1 = exp_overapproximation(m, 1.0, 4)
2×2 IntervalMatrix{Float64,IntervalArithmetic.Interval{Float64},Array{IntervalArithmetic.Interval{Float64},2}}:
 [-118.405, 126.84]   [-121.004, 131.545]
 [-131.545, 121.004]  [-118.405, 126.84] 

julia> overapp2 = scale_and_square(m, 5, 1.0, 4)
2×2 IntervalMatrix{Float64,IntervalArithmetic.Interval{Float64},Array{IntervalArithmetic.Interval{Float64},2}}:
 [-3.64854, 1.33517]  [-1.43363, 4.5463] 
 [-4.5463, 1.43363]   [-3.64854, 1.33517]

julia> underapp = exp_underapproximation(m, 1.0, 4)
2×2 IntervalMatrix{Float64,IntervalArithmetic.Interval{Float64},Array{IntervalArithmetic.Interval{Float64},2}}:
  [-7.53631, 9.15004]  [-10.4537, 18.1044] 
 [-19.0118, 10.3238]    [-7.53631, 9.15004]

julia> overapp2 ⊆ overapp1  # scaling and squaring is more precise
true

julia> underapp ⊆ overapp1  # underapproximation is contained in old result
true

julia> underapp ⊆ overapp2  # underapprox. not contained in scaling-and-squaring result
false
```