### PR TITLE
#75 - Truncated exponential sum

### DIFF
--- a/src/exponential.jl
+++ b/src/exponential.jl
@@ -121,19 +121,25 @@ function quadratic_expansion(A::IntervalMatrix, α::Real, β::Real)
     return IntervalMatrix(B)
 end
 
-function _truncated_exponential_series(A::IntervalMatrix{T}, t, p;
+function _truncated_exponential_series(A::IntervalMatrix{T}, t, p::Integer;
                                        n=checksquare(A)) where {T}
-    @assert p > 1 "the order $p < 2 is not supported"
-
-    # indices i = 1 and i = 2
-    S = quadratic_expansion(A, t)
+    if p == 0
+        # index i = 0 (identity matrix)
+        return IntervalMatrix(Interval(one(T)) * I, n)
+    elseif p == 1
+        # index i = 1
+        S = A * t
+    else
+        # indices i = 1 and i = 2
+        S = quadratic_expansion(A, t)
+    end
 
     # index i = 0, (identity matrix, added implicitly)
     for i in 1:n
         S[i, i] += one(T)
     end
 
-    if p == 2
+    if p < 3
         return S
     end
 

--- a/src/exponential.jl
+++ b/src/exponential.jl
@@ -138,14 +138,15 @@ function _truncated_exponential_series(A::IntervalMatrix{T}, t, p;
     end
 
     # indices i >= 3
-    Ai = square(A)
+    pow = IntervalMatrixPower(A)
+    increment!(pow)
     fact_num = t^2
     fact_denom = 2
     for i in 3:p
         fact_num *= t
         fact_denom *= i
-        Ai *= A
-        S += Ai * (fact_num / fact_denom)
+        Aⁱ = increment!(pow)
+        S += Aⁱ * (fact_num / fact_denom)
     end
 
     return S
@@ -281,20 +282,20 @@ function exp_underapproximation(A::IntervalMatrix{T, Interval{T}}, t, p) where {
 
     Y = zeros(n, n)
     LA = inf(A)
-    Ail = LA^2
+    Aⁱl = LA^2
     Z = zeros(n, n)
     RA = sup(A)
-    Air = RA^2
+    Aⁱr = RA^2
     fact_num = t^2
     fact_denom = 2
     for i in 3:p
         fact_num *= t
         fact_denom *= i
         fact = fact_num / fact_denom
-        Ail *= LA
-        Y += Ail * fact
-        Air *= RA
-        Z += Air * fact
+        Aⁱl *= LA
+        Y += Aⁱl * fact
+        Aⁱr *= RA
+        Z += Aⁱr * fact
     end
 
     B = IntervalMatrix(Matrix{Interval{T}}(undef, n , n))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using IntervalMatrices, Test, LinearAlgebra
 
-using IntervalMatrices: scale_and_square
+using IntervalMatrices: _truncated_exponential_series, scale_and_square
 
 @testset "Interval arithmetic" begin
     a = -1.5 ± 0.5
@@ -67,6 +67,11 @@ end
 
 @testset "Interval matrix exponential" begin
     m = IntervalMatrix([-1.1..0.9 -4.1.. -3.9; 3.9..4.1 -1.1..0.9])
+
+    for i in 0:4
+        _truncated_exponential_series(m, 1.0, i)
+    end
+
     overapp1 = exp_overapproximation(m, 1.0, 4)
     overapp2 = scale_and_square(m, 5, 1.0, 4)
     underapp = exp_underapproximation(m, 1.0, 4)


### PR DESCRIPTION
This is the first step for #75. The proposed starting index `i0` is missing.
* first commit: just a refactoring of the old code (plus adding assertions `p < 2` that were not checked before)
* second commit: use the new `IntervalMatrixPower` type
* third commit: generalize code to nonnegative `p`

An example shows that the simple use of `square` in `IntervalMatrixPower` already pays off.
```julia
julia> A = rand(IntervalMatrix)
2×2 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
 [-0.152272, 1.1966]   [-0.340722, 1.00641]
 [-0.688822, 1.30464]  [-1.08989, 2.67171]

julia> exp_overapproximation(A, 1.0, 10)  # master
2×2 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
 [-1.39748, 7.5724]   [-3.65965, 9.33968]
 [-6.39121, 12.0942]  [-5.87441, 21.2407]

julia> d1 = diam(exp_overapproximation(A, 1.0, 10))
2×2 Array{Float64,2}:
  8.96987  12.9993
 18.4854   27.115 

julia> exp_overapproximation(A, 1.0, 10)  # this branch
2×2 IntervalMatrix{Float64,Interval{Float64},Array{Interval{Float64},2}}:
 [-1.23017, 7.5724]   [-3.46151, 9.33968]
 [-6.39121, 12.0942]  [-4.36419, 21.2407]

julia> d2 = diam(exp_overapproximation(A, 1.0, 10))
2×2 Array{Float64,2}:
  8.80256  12.8012
 18.4854   25.6048

julia> d1 - d2
2×2 Array{Float64,2}:
 0.167307  0.198139
 0.0       1.51022 
```