### PR TITLE
#117 - Faster opnorm

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -156,10 +156,20 @@ The matrix ``p``-norm of an interval matrix ``A`` is defined as
 ```
 
 where ``\\max`` and ``|·|`` are taken elementwise.
+
+### Algorithm
+
+We exploit that
+
+```math
+    ‖A‖_p = ‖\\max(-\\text{inf}(A), \\text{sup}(A))‖_p
+```
+
+to avoid taking the absolute (``|·|``).
 """
 function LinearAlgebra.opnorm(A::IntervalMatrix, p::Real=Inf)
     if p == Inf || p == 1
-        return LinearAlgebra.opnorm(max.(abs.(inf(A)), abs.(sup(A))), p)
+        return LinearAlgebra.opnorm(max.((-).(inf(A)), sup(A)), p)
     else
         error("the interval matrix norm for this value of p=$p is not implemented")
     end


### PR DESCRIPTION
Closes #117.

Thanks to the fusing, the old version was already memory efficient. Still, taking the absolute has a (very) small performance impact.

```julia
julia> A = rand(IntervalMatrix, 100);

julia> @btime opnorm($A)  # this branch
  44.356 μs (8 allocations: 234.64 KiB)
127.35643894432378

julia> @btime opnorm($A)  # master
  45.334 μs (8 allocations: 234.64 KiB)
127.35643894432378

julia> B = IntervalMatrix(fill(Interval(-1.0), 100, 100));

julia> @btime opnorm($B)  # this branch
  44.525 μs (8 allocations: 234.64 KiB)
100.0

julia> @btime opnorm($B)  # master
  45.402 μs (8 allocations: 234.64 KiB)
100.0

julia> C = IntervalMatrix(fill(Interval(1.0), 100, 100));

julia> @btime opnorm($C)  # this branch
  44.350 μs (8 allocations: 234.64 KiB)
100.0

julia> @btime opnorm($C)  # master
  45.774 μs (8 allocations: 234.64 KiB)
100.0
```