### PR TITLE
#127 - Faster opnorm, part 2

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -194,7 +194,7 @@ end
 function _opnorm_1(A::IntervalMatrix{T}) where {T}
     m, n = size(A)
     res = zero(T)
-    @inbounds @simd for j in 1:m
+    @inbounds @simd for j in 1:n
         acc = zero(T)
         for i in 1:n
             x = A[i, j]

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -196,7 +196,7 @@ function _opnorm_1(A::IntervalMatrix{T}) where {T}
     res = zero(T)
     @inbounds @simd for j in 1:n
         acc = zero(T)
-        for i in 1:n
+        for i in 1:m
             x = A[i, j]
             acc += max(abs(inf(x)), abs(sup(x)))
         end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -160,16 +160,6 @@ The matrix ``p``-norm of an interval matrix ``A`` is defined as
 ```
 
 where ``\\max`` and ``|·|`` are taken elementwise.
-
-### Algorithm
-
-We exploit that
-
-```math
-    ‖A‖_p = ‖\\max(-\\text{inf}(A), \\text{sup}(A))‖_p
-```
-
-to avoid taking the absolute (``|·|``).
 """
 function LinearAlgebra.opnorm(A::IntervalMatrix, p::Real=Inf)
     if p == Inf

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -182,16 +182,14 @@ function LinearAlgebra.opnorm(A::IntervalMatrix, p::Real=Inf)
 end
 
 # The operator norm in the infinity norm corresponds to the
-# maximum absolute value row-sum. Julia has column-major
-# ordering so for efficiency we iterate over the transpose of A.
-function _opnorm_inf(A::IntervalMatrix{N}) where {N}
+# maximum absolute value row-sum.
+function _opnorm_inf(A::IntervalMatrix{T}) where {T}
     m, n = size(A)
-    res = zero(N)
-    At = transpose(A)
-    @inbounds @simd for j in 1:m
-        acc = zero(N)
-        for i in 1:n
-            x = At[i, j]
+    res = zero(T)
+    @inbounds @simd for i in 1:m
+        acc = zero(T)
+        for j in 1:n
+            x = A[i, j]
             acc += max(abs(inf(x)), abs(sup(x)))
         end
         if acc > res
@@ -203,11 +201,11 @@ end
 
 # The operator norm in the 1-norm corresponds to the
 # maximum absolute value column-sum.
-function _opnorm_1(A::IntervalMatrix{N}) where {N}
+function _opnorm_1(A::IntervalMatrix{T}) where {T}
     m, n = size(A)
-    res = zero(N)
+    res = zero(T)
     @inbounds @simd for j in 1:m
-        acc = zero(N)
+        acc = zero(T)
         for i in 1:n
             x = A[i, j]
             acc += max(abs(inf(x)), abs(sup(x)))


### PR DESCRIPTION
Closes #127.

---

```julia
julia> M = rand(IntervalMatrix, 100);

julia> opnorm(M, Inf)
128.9128489817419

julia> @btime opnorm($M, Inf) # master
  23.559 μs (8 allocations: 234.64 KiB)
128.9128489817419

julia> @btime opnorm($M, Inf) # this branch
  18.804 μs (0 allocations: 0 bytes)
128.9128489817419

julia> @btime opnorm($M, 1) # master
  24.221 μs (8 allocations: 234.64 KiB)
130.11834643451667

julia> @btime opnorm($M, 1) # this branch
  17.752 μs (0 allocations: 0 bytes)
130.11834643451667
```