### PR TITLE
Add Horner scheme

### DIFF
--- a/docs/src/lib/methods.md
+++ b/docs/src/lib/methods.md
@@ -43,6 +43,7 @@ index
 
 ```@docs
 exp_overapproximation
+horner
 scale_and_square
 exp_underapproximation
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using IntervalMatrices, Test, LinearAlgebra
 
-using IntervalMatrices: _truncated_exponential_series, scale_and_square
+using IntervalMatrices: _truncated_exponential_series, horner,
+                        scale_and_square
 
 @testset "Interval arithmetic" begin
     a = -1.5 ± 0.5
@@ -87,11 +88,12 @@ end
     end
 
     overapp1 = exp_overapproximation(m, 1.0, 4)
-    overapp2 = scale_and_square(m, 5, 1.0, 4)
+    overapp2 = horner(m, 10)
+    overapp3 = scale_and_square(m, 5, 1.0, 4)
     underapp = exp_underapproximation(m, 1.0, 4)
 
     @test underapp isa IntervalMatrix
-    for overapp in [overapp1, overapp2]
+    for overapp in [overapp1, overapp2, overapp3]
         @test overapp isa IntervalMatrix
     end
 end


### PR DESCRIPTION
This is basically the implementation by @mforets [here](https://nbviewer.jupyter.org/github/mforets/escritoire/blob/master/2020/Week7/IM_Horner.ipynb).

(I observed that at some point the exponential remainder starts growing again, but this is not a problem of this PR → #145.)

```julia
julia> m = IntervalMatrix([-1.1..0.9 -4.1.. -3.9; 3.9..4.1 -1.1..0.9]);

julia> for K in [4, 6, 8, 20, 30]
           H = horner_scheme(m, K)
       end
K: 4
H: Interval{Float64}[[-6.59711, 16.4024] [-4.60191, 16.6734]; [-16.6734, 4.60191] [-6.59711, 16.4024]]
R: Interval{Float64}[[-107.653, 107.653] [-107.653, 107.653]; [-107.653, 107.653] [-107.653, 107.653]]
result: Interval{Float64}[[-114.25, 124.055] [-112.255, 124.326]; [-124.326, 112.255] [-114.25, 124.055]]
diam: [238.30443375030262 236.58025875030262; 236.58025875030262 238.30443375030262]
K: 6
H: Interval{Float64}[[-16.098, 11.2656] [-15.8269, 12.8829]; [-12.8829, 15.8269] [-16.098, 11.2656]]
R: Interval{Float64}[[-48.5097, 48.5097] [-48.5097, 48.5097]; [-48.5097, 48.5097] [-48.5097, 48.5097]]
result: Interval{Float64}[[-64.6077, 59.7752] [-64.3365, 61.3926]; [-61.3926, 64.3365] [-64.6077, 59.7752]]
diam: [124.38282465585809 125.72902259752476; 125.72902259752476 124.38282465585809]
K: 8
H: Interval{Float64}[[-16.9448, 18.0497] [-15.3549, 18.6421]; [-18.6421, 15.3549] [-16.9448, 18.0497]]
R: Interval{Float64}[[-14.8526, 14.8526] [-14.8526, 14.8526]; [-14.8526, 14.8526] [-14.8526, 14.8526]]
result: Interval{Float64}[[-31.7974, 32.9023] [-30.2075, 33.4947]; [-33.4947, 30.2075] [-31.7974, 32.9023]]
diam: [64.69952648085506 63.70205977610654; 63.70205977610654 64.69952648085506]
K: 20
H: Interval{Float64}[[-18.5586, 18.6197] [-17.1485, 19.3592]; [-19.3592, 17.1485] [-18.5586, 18.6197]]
R: Interval{Float64}[[-2.77417e-05, 2.77417e-05] [-2.77417e-05, 2.77417e-05]; [-2.77417e-05, 2.77417e-05] [-2.77417e-05, 2.77417e-05]]
result: Interval{Float64}[[-18.5586, 18.6197] [-17.1485, 19.3592]; [-19.3592, 17.1485] [-18.5586, 18.6197]]
diam: [37.17821738633965 36.507641933692234; 36.507641933692234 37.17821738633965]
K: 30
H: Interval{Float64}[[-18.5586, 18.6197] [-17.1485, 19.3592]; [-19.3592, 17.1485] [-18.5586, 18.6197]]
R: Interval{Float64}[[-452.145, 452.145] [-452.145, 452.145]; [-452.145, 452.145] [-452.145, 452.145]]
result: Interval{Float64}[[-470.704, 470.765] [-469.294, 471.504]; [-471.504, 469.294] [-470.704, 470.765]]
diam: [941.4678769593615 940.7973015555041; 940.7973015555041 941.4678769593615]
```