### PR TITLE
added missing functions (radius, issubset) and fixes in real-valued functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 docs/build/
 docs/site/
+
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalMatrices"
 uuid = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9"
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,6 +1,6 @@
 import Base: similar, split, ∈, ⊆, ∩, ∪
 import Random: rand
-import IntervalArithmetic: inf, sup, mid, diam, radius, ⊂
+import IntervalArithmetic: inf, sup, mid, diam, radius, ⊂, hull
 
 """
     AbstractIntervalMatrix{IT} <: AbstractMatrix{IT}
@@ -567,10 +567,34 @@ function ∩(A::IntervalMatrix, B::IntervalMatrix)
     return map((x, y) -> x ∩ y, A, B)
 end
 
+
+"""
+    hull(A::IntervalMatrix, B::IntervalMatrix)
+
+Finds the interval hull of two interval matrices. This is equivalent to [`∪`](@ref).
+
+### Input
+
+- `A` -- interval matrix
+- `B` -- interval matrix (of the same shape as `A`)
+
+### Output
+
+A new matrix `C` of the same shape as `A` such that
+`C[i, j] = hull(A[i, j], B[i, j])` for each `i` and `j`.
+"""
+function hull(A::IntervalMatrix, B::IntervalMatrix)
+    @assert size(A) == size(B) "incompatible matrix sizes (A: $(size(A)), B: " *
+                               "$(size(B)))"
+
+    return map((x, y) -> hull(x, y), A, B)
+end
+
 """
     ∪(A::IntervalMatrix, B::IntervalMatrix)
 
 Finds the interval union (hull) of two interval matrices.
+This is equivalent to [`hull`](@ref).
 
 ### Input
 
@@ -582,13 +606,7 @@ Finds the interval union (hull) of two interval matrices.
 A new matrix `C` of the same shape as `A` such that
 `C[i, j] = A[i, j] ∪ B[i, j]` for each `i` and `j`.
 """
-function ∪(A::IntervalMatrix, B::IntervalMatrix)
-    m, n = size(A)
-    @assert size(A) == size(B) "incompatible matrix sizes (A: $(size(A)), B: " *
-                               "$(size(B)))"
-
-    return map((x, y) -> x ∪ y, A, B)
-end
+∪(A::IntervalMatrix, B::IntervalMatrix) = hull(A, B)
 
 """
     diam_norm(A::IntervalMatrix, p=Inf)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -564,7 +564,7 @@ function ∩(A::IntervalMatrix, B::IntervalMatrix)
     @assert size(A) == size(B) "incompatible matrix sizes (A: $(size(A)), B: " *
                                "$(size(B)))"
 
-    return map((x, y) -> x ∩ y, A, B)
+    return IntervalMatrix(map((x, y) -> x ∩ y, A, B))
 end
 
 
@@ -587,7 +587,7 @@ function hull(A::IntervalMatrix, B::IntervalMatrix)
     @assert size(A) == size(B) "incompatible matrix sizes (A: $(size(A)), B: " *
                                "$(size(B)))"
 
-    return map((x, y) -> hull(x, y), A, B)
+    return IntervalMatrix(map((x, y) -> hull(x, y), A, B))
 end
 
 """

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,6 +1,6 @@
 import Base: similar, split, ∈, ⊆, ∩, ∪
 import Random: rand
-import IntervalArithmetic: inf, sup, mid, diam, radius, ⊂, hull
+import IntervalArithmetic: inf, sup, mid, diam, radius, hull
 
 """
     AbstractIntervalMatrix{IT} <: AbstractMatrix{IT}
@@ -371,33 +371,6 @@ function ⊆(A::AbstractIntervalMatrix, B::AbstractIntervalMatrix)
     m, n = size(A)
     @inbounds for j in 1:n, i in 1:m
         if !(A[i, j] ⊆ B[i, j])
-            return false
-        end
-    end
-    return true
-end
-
-"""
-    ⊂(A::AbstractIntervalMatrix, B::AbstractIntervalMatrix)
-
-Check whether an interval matrix is stricly contained in another interval matrix.
-
-### Input
-
-- `A` -- interval matrix
-- `B` -- interval matrix
-
-### Output
-
-`true` iff `A[i, j] ⊂ B[i, j]` for all `i, j`.
-"""
-function ⊂(A::AbstractIntervalMatrix, B::AbstractIntervalMatrix)
-    @assert size(A) == size(B) "incompatible matrix sizes $(size(A)) and " *
-                               "$(size(B))"
-
-    m, n = size(A)
-    @inbounds for j in 1:n, i in 1:m
-        if !(A[i, j] ⊂ B[i, j])
             return false
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,10 +69,12 @@ end
     r = sup(m)
     c = mid(m)
     d = diam(m)
+    rad = radius(m)
     m2 = copy(m)
     @test m2 isa IntervalMatrix && m.mat == m2.mat
     @test l == inf.(m) && r == sup.(m) && c == mid.(m)
     @test d ≈ r - l
+    @test rad ≈ d/2
     sm = scale(m, 2.0)
     @test sm ==  2.0 .* m
     @test sm ≠ m
@@ -81,6 +83,7 @@ end
     m3 = IntervalMatrix([-2.0..2.0 -2.0..0.0; 0.0..2.0 -1.0..1.0])
     m4 = IntervalMatrix([-1.0..1.0 -1.0..1.0; -1.0..1.0 -2.0..2.0])
     @test m3 ∩ m4 == IntervalMatrix([-1.0..1.0 -1.0..0.0; 0.0..1.0 -1.0..1.0])
+    @test m3 ∪ m4 == IntervalMatrix([-2.0..2.0 -2.0..1.0; -1.0..2.0 -2.0..2.0])
     @test diam_norm(m3) ≈ 6.0 # default diameter p-norm is Inf
     @test diam_norm(m3, 1) ≈ 6.0
 end
@@ -122,6 +125,8 @@ end
     m1 = IntervalMatrix([-1.1..0.9 -4.1.. -3.9; 3.9..4.1 -1.1..0.9])
     m2 = IntervalMatrix([-1.2..1.0 -4.1.. -3.9; 3.9..4.2 -1.2..0.9])
     @test m1 ⊆ m2 && !(m2 ⊆ m1)
+    @test m1 ⊂ m2
+    @test !(m1 ⊂ m1)
 end
 
 @testset "Interval matrix rand" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,9 +124,11 @@ end
 @testset "Interval matrix inclusion" begin
     m1 = IntervalMatrix([-1.1..0.9 -4.1.. -3.9; 3.9..4.1 -1.1..0.9])
     m2 = IntervalMatrix([-1.2..1.0 -4.1.. -3.9; 3.9..4.2 -1.2..0.9])
+    m3 = IntervalMatrix([-1.2..1.0 -4.2.. -3.9; 3.9..4.2 -1.2..0.9])
     @test m1 ⊆ m2 && !(m2 ⊆ m1)
-    @test m1 ⊂ m2
+    @test m1 ⊂ m3
     @test !(m1 ⊂ m1)
+    @test !(m1 ⊂ m2)
 end
 
 @testset "Interval matrix rand" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,11 +124,8 @@ end
 @testset "Interval matrix inclusion" begin
     m1 = IntervalMatrix([-1.1..0.9 -4.1.. -3.9; 3.9..4.1 -1.1..0.9])
     m2 = IntervalMatrix([-1.2..1.0 -4.1.. -3.9; 3.9..4.2 -1.2..0.9])
-    m3 = IntervalMatrix([-1.2..1.0 -4.2.. -3.9; 3.9..4.2 -1.2..0.9])
     @test m1 ⊆ m2 && !(m2 ⊆ m1)
-    @test m1 ⊂ m3
-    @test !(m1 ⊂ m1)
-    @test !(m1 ⊂ m2)
+
 end
 
 @testset "Interval matrix rand" begin


### PR DESCRIPTION
Summary of the PR

- Implemented fallback from U, now it computes the hull of interval matrices, similar to what it does in `IntervalArithmetic.jl`. Should I also add `hull`? So in IntervalArithmetic, `hull` and `U` are synonyms (fixes #168 )

- Extended C (is strictly subset) from interval linear algebra, this is sometimes needed e.g. in verified algorithms such as epsilon inflation

- Fixed intersection of interval matrices (fixes #169 )

- Fixed real valued function (mid, diam, inf, etc.) to preserve the structure of the matrix (fixes #167 )

This seems to introduce a failure for interval matrix exponential, I need to investigate that.