### PR TITLE
fix #204

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalMatrices"
 uuid = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9"
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -184,3 +184,8 @@ function ±(C::MT, S::MT) where {T, MT<:AbstractMatrix{T}}
 
     return IntervalMatrix(map((x, y) -> x ± y, C, S))
 end
+
+for op in (:Adjoint, :Bidiagonal, :Diagonal, :Hermitian,
+    :SymTridiagonal, :Symmetric, :Transpose, :Tridiagonal, :UpperHessenberg)
+    @eval LinearAlgebra.$op(A::IntervalMatrix) = IntervalMatrix($op(A.mat))
+end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -40,3 +40,13 @@ end
     @test m2 isa IntervalMatrix{Float64}
     @test eltype(m2) == Complex{Interval{Float64}}
 end
+
+@testset "special matrices" begin
+    A = rand(IntervalMatrix)
+    Aₛ = Symmetric(A)
+
+    @test Aₛ isa IntervalMatrix
+    @test Aₛ.mat isa Symmetric
+
+    @test Matrix(Aₛ) isa Matrix
+end


### PR DESCRIPTION
### Description

overload constructors of special matrices for interval matrices. fix #204 

### Example

```julia
julia> using IntervalMatrices, LinearAlgebra

julia> A = rand(IntervalMatrix)
2×2 IntervalMatrix{Float64, Interval{Float64}, Matrix{Interval{Float64}}}:
 [-1.53871, 0.173617]  [-2.01894, -1.27604]
 [-2.33581, 1.19427]   [-0.30295, -0.192572]

julia> Symmetric(A)
2×2 IntervalMatrix{Float64, Interval{Float64}, Symmetric{Interval{Float64}, Matrix{Interval{Float64}}}}:
 [-1.53871, 0.173617]  [-2.01894, -1.27604]
 [-2.01894, -1.27604]  [-0.30295, -0.192572]

julia> Diagonal(A)
2×2 IntervalMatrix{Float64, Interval{Float64}, Diagonal{Interval{Float64}, Vector{Interval{Float64}}}}:
    [-1.53871, 0.173617]  [0, 0]
 [0, 0]                      [-0.30295, -0.192572]

julia> Symmetric(A).mat
2×2 Symmetric{Interval{Float64}, Matrix{Interval{Float64}}}:
 [-1.53871, 0.173617]  [-2.01894, -1.27604]
 [-2.01894, -1.27604]  [-0.30295, -0.192572]

julia> Matrix(Symmetric(A))
2×2 Matrix{Interval{Float64}}:
 [-1.53871, 0.173617]  [-2.01894, -1.27604]
 [-2.01894, -1.27604]  [-0.30295, -0.192572]
```