### PR TITLE
Avoid redefinition of '==' in tests

### DIFF
--- a/test/affine.jl
+++ b/test/affine.jl
@@ -5,10 +5,10 @@
     P = AffineIntervalMatrix1(A0, A1, λ)
 
     @test size(P) == (2, 2)
-    @test P[1, 1] == interval(1)
-    @test P[1, 2] == interval(0, 1)
+    @test P[1, 1] ⩵ interval(1)
+    @test P[1, 2] ⩵ interval(0, 1)
     P[1, 1] = 2.0
-    @test P[1, 1] == interval(2)
+    @test P[1, 1] ⩵ interval(2)
 
     Q = copy(P)
     @test Q == P && Q isa AffineIntervalMatrix1
@@ -28,10 +28,10 @@ end
     P = AffineIntervalMatrix(A0, [A1, A2], [λ1, λ2])
 
     @test size(P) == (2, 2)
-    @test P[1, 1] == interval(1)
-    @test P[1, 2] == interval(0, 2)
+    @test P[1, 1] ⩵ interval(1)
+    @test P[1, 2] ⩵ interval(0, 2)
     P[1, 1] = 5.0
-    @test P[1, 1] == interval(5)
+    @test P[1, 1] ⩵ interval(5)
 
     Q = copy(P)
     @test Q == P && Q isa AffineIntervalMatrix

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -1,10 +1,10 @@
 @testset "Interval arithmetic" begin
     a = interval(-2, -1)
     b = interval(-1, 1)
-    @test a + b == interval(-3, 0)
-    @test a * b == interval(-2, 2)
-    @test a * b + a == interval(-4, 1)
-    @test a * (b + 1) == interval(-4, 0)
+    @test a + b ⩵ interval(-3, 0)
+    @test a * b ⩵ interval(-2, 2)
+    @test a * b + a ⩵ interval(-4, 1)
+    @test a * (b + 1) ⩵ interval(-4, 0)
 end
 
 @testset "Interval matrix arithmetic" begin
@@ -27,7 +27,7 @@ end
 
     B = A - A
     @test B isa IntervalMatrix && inf(B[1, 1]) ≈ inf(a₋) && sup(B[1, 1]) ≈ sup(a₋) &&
-          B[1, 2] == b₋ && B[2, 1] == c₋ && B[2, 2] == d₋
+          B[1, 2] ⩵ b₋ && B[2, 1] ⩵ c₋ && B[2, 2] ⩵ d₋
 
     # arithmetic with an interval or number
     for x in (interval(0, 2), 2.0)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -4,10 +4,10 @@
     y = convert(Interval{Float64}, x)
     # `===` is not applicable here because it just checks value equivalence
     # for (immutable) `Interval`s
-    @test y == x && y isa Interval{Float64}
+    @test y ⩵ x && y isa Interval{Float64}
 
     y = convert(Interval{Float32}, x)
-    @test y == x && y isa Interval{Float32}
+    @test y ⩵ x && y isa Interval{Float32}
 end
 
 @testset "Interval matrix construction" begin

--- a/test/exponential.jl
+++ b/test/exponential.jl
@@ -8,7 +8,7 @@ using IntervalMatrices: TaylorOverapproximation,
                         _exp_remainder_series
 
 @testset "Interval matrix exponential" begin
-    @test quadratic_expansion(interval(-3, 3), 1.0, 2.0) == interval(-0.125, 21)
+    @test quadratic_expansion(interval(-3, 3), 1.0, 2.0) ⩵ interval(-0.125, 21)
 
     M = IntervalMatrix([interval(-1.1, 0.9) interval(-4.1, -3.9);
                         interval(3.9, 4.1) interval(-1.1, 0.9)])
@@ -59,7 +59,7 @@ end
 
     @test base(pow) === m
     @test get(pow) === pow.Mᵏ
-    @test index(pow) === 1
+    @test index(pow) == 1
 
     pow2 = copy(pow)
     @test pow2 isa IntervalMatrixPower && get(pow) == get(pow2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,9 +7,11 @@ using IntervalMatrices: _truncated_exponential_series,
                         correction_hull,
                         input_correction
 
+# IntervalArithmetic removed interval comparison in v0.22
 @static if PkgVersion.Version(IntervalMatrices.IntervalArithmetic) >= v"0.22"
-    # equality test for convenience
-    Base.:(==)(x::Interval, y::Interval) = isequal_interval(x, y)
+    ⩵(x::Interval, y::Interval) = isequal_interval(x, y)
+else
+    ⩵(x::Interval, y::Interval) = ==(x, y)
 end
 
 include("models.jl")

--- a/test/setops.jl
+++ b/test/setops.jl
@@ -55,7 +55,7 @@ end
     for i in 1:3
         # sample a random interval from the matrix (Base method)
         mr = rand(m)
-        @test mr ∈ m && mr isa Interval
+        @test any(mr ⩵ y for y in m) && mr isa Interval
 
         # sample a concrete matrix instantiation
         ms = sample(m)


### PR DESCRIPTION
This avoids a warning in the tests about a method redefinition.