### PR TITLE
Rename `get` -> `matrix`

### DIFF
--- a/docs/src/lib/methods.md
+++ b/docs/src/lib/methods.md
@@ -44,7 +44,7 @@ set_multiplication_mode
 ```@docs
 increment!
 increment
-get
+matrix
 base
 index
 ```

--- a/src/IntervalMatrices.jl
+++ b/src/IntervalMatrices.jl
@@ -6,7 +6,7 @@ using LinearAlgebra: checksquare
 using Random: AbstractRNG, GLOBAL_RNG, seed!
 import Random: rand
 
-import Base: copy, get,
+import Base: copy,
              +, -, *, /, \,
              size, IndexStyle, getindex, setindex!,
              similar, ∈, ⊆, ∩, ∪, real, imag
@@ -68,6 +68,7 @@ export inf, sup,
 
 export IntervalMatrixPower,
        increment!, increment,
+       matrix,
        base,
        index
 

--- a/src/operations/power.jl
+++ b/src/operations/power.jl
@@ -34,7 +34,7 @@ julia> increment(pow)
  [8.0, 8.0]  [-1.0, 21.0]
  [0.0, 0.0]  [-1.0, 1.0]
 
-julia> get(pow)
+julia> matrix(pow)
 2×2 IntervalMatrix{Float64, Interval{Float64}, Matrix{Interval{Float64}}}:
  [4.0, 4.0]  [2.0, 9.0]
  [0.0, 0.0]  [0.0, 1.0]
@@ -210,7 +210,7 @@ function base(pow::IntervalMatrixPower)
 end
 
 """
-    get(pow::IntervalMatrixPower)
+    matrix(pow::IntervalMatrixPower)
 
 Return the matrix represented by a wrapper of a matrix power.
 
@@ -222,7 +222,7 @@ Return the matrix represented by a wrapper of a matrix power.
 
 The matrix power represented by the wrapper.
 """
-function get(pow::IntervalMatrixPower)
+function matrix(pow::IntervalMatrixPower)
     return pow.Mᵏ
 end
 

--- a/test/exponential.jl
+++ b/test/exponential.jl
@@ -58,15 +58,15 @@ end
     pow = IntervalMatrixPower(m)
 
     @test base(pow) === m
-    @test get(pow) === pow.Mᵏ
+    @test matrix(pow) === pow.Mᵏ
     @test index(pow) == 1
 
     pow2 = copy(pow)
-    @test pow2 isa IntervalMatrixPower && get(pow) == get(pow2)
+    @test pow2 isa IntervalMatrixPower && matrix(pow) == matrix(pow2)
 
     pow2 = IntervalMatrixPower(m, 2)
     pow3 = increment(pow)
-    @test pow3 isa IntervalMatrix && pow3 == get(pow2)
+    @test pow3 isa IntervalMatrix && pow3 == matrix(pow2)
 
     increment!(pow)  # next step is a power of two
     @test index(pow) == 2


### PR DESCRIPTION
Reason: `get` is a `Base` function and has a somewhat different meaning associated.

This is a breaking change.