### PR TITLE
Aqua v0.8.9 tests only for local ambiguities

### DIFF
--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -24,8 +24,5 @@ import PkgVersion, Aqua
     end
 
     Aqua.test_all(IntervalMatrices; stale_deps=stale_deps, undefined_exports=undefined_exports,
-                  ambiguities=false, piracies=piracies)
-
-    # do not warn about ambiguities in dependencies
-    Aqua.detect_ambiguities(IntervalMatrices)
+                  piracies=piracies)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,5 +6,5 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Aqua = "0.8"
+Aqua = "0.8.9"
 PkgVersion = "0.3.3"


### PR DESCRIPTION
The CI errors are unrelated.