### PR TITLE
Consistent spelling

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -9,7 +9,7 @@ abstract type AbstractIntervalMatrix{IT} <: AbstractMatrix{IT} end
     IntervalMatrix{T, IT, MT<:AbstractMatrix{IT}} <: AbstractIntervalMatrix{IT}
 
 An interval matrix i.e. a matrix whose coefficients are intervals. This type is
-parametrized in the number field, the interval type, and the matrix type.
+parameterized in the number field, the interval type, and the matrix type.
 
 ### Fields
 


### PR DESCRIPTION
The spelling "parametrized" is actually widely accepted. We can alternatively add it to the ignored words. But I do not mind using the slightly longer version, so that is what this PR proposes.