### PR TITLE
v0.12.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalMatrices"
 uuid = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9"
-version = "0.11.2"
+version = "0.12.0"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"


### PR DESCRIPTION
This should be a breaking release because `IntervalArithmetic` v0.23.0 changed the matrix multiplication default to `:fast`, which can be much less precise. Alternatively, we could automatically set it to `:slow` in this package, but that may also lead to confusing behavior for users who expect this new behavior.