### PR TITLE
Use `^` instead of `pown`

### DIFF
--- a/src/init_IntervalArithmetic.jl
+++ b/src/init_IntervalArithmetic.jl
@@ -21,8 +21,6 @@ else  # vIA < v"0.22"
 
     intersect_interval(a::Interval, b::Interval) = intersect(a, b)
 
-    pown(x, y) = x^y
-
     if vIA >= v"0.21"
         # `convert` was temporarily removed in IntervalArithmetic v0.21 until v0.22
         Base.convert(::Type{Interval{T}}, x::Number) where {T} = interval(T(x))

--- a/src/operations/arithmetic.jl
+++ b/src/operations/arithmetic.jl
@@ -83,7 +83,7 @@ function square(A::IntervalMatrix)
 
     # case i == j
     @inbounds for j in 1:n
-        B[j, j] = pown(A[j, j], 2)
+        B[j, j] = A[j, j]^2
         for k in 1:n
             k == j && continue
             B[j, j] += A[j, k] * A[k, j]


### PR DESCRIPTION
This is an equivalent fix as in #283 but more efficient.