### PR TITLE
Resolve ambiguity warning in v1.13

### DIFF
--- a/src/operations/arithmetic.jl
+++ b/src/operations/arithmetic.jl
@@ -45,15 +45,13 @@ for T in (:AbstractMatrix, :(LinearAlgebra.Diagonal),
     end
 end
 @static if VERSION >= v"1.3"
-    for T in [:(LinearAlgebra.Adjoint{T,
-                                      S} where {T,
-                                                S<:(LinearAlgebra.UpperHessenberg{T,
-                                                                                  S} where {S<:AbstractMatrix{T}})}),
-              :(LinearAlgebra.Transpose{T,
-                                        S} where {T,
-                                                  S<:(LinearAlgebra.UpperHessenberg{T,
-                                                                                    S} where {S<:AbstractMatrix{T}})}),
-              :(LinearAlgebra.UpperHessenberg)]
+    for T in [:(Union{LinearAlgebra.Adjoint{T,
+                                            S} where {T,
+                      S<:(LinearAlgebra.UpperHessenberg{T,S} where {S<:AbstractMatrix{T}})},
+                      LinearAlgebra.Transpose{T,
+                                              S} where {T,
+                      S<:(LinearAlgebra.UpperHessenberg{T,S} where {S<:AbstractMatrix{T}})},
+                      LinearAlgebra.UpperHessenberg})]
         @eval begin
             \(M1::IntervalMatrix, M2::$T) = IntervalMatrix(M1.mat \ M2)
             \(M1::$T, M2::IntervalMatrix) = IntervalMatrix(M1 \ M2.mat)


### PR DESCRIPTION
x-ref: https://github.com/JuliaLang/julia/issues/62262

Basically, `detect_ambiguity` does not yield the same result for a `Union` type on the one hand and each element in the `Union` on the other hand. Up to (including) v1.12, this was fine, but in v1.13, this will fail. So the solution here is to put all the types into a `Union`. The behavior is still the same.